### PR TITLE
Update AddDeviceToGroupBasedOnPrimaryUserGroupMembership.ps1

### DIFF
--- a/Intune/RBAC/DeviceScopeTags/AddDeviceToGroupBasedOnPrimaryUserGroupMembership.ps1
+++ b/Intune/RBAC/DeviceScopeTags/AddDeviceToGroupBasedOnPrimaryUserGroupMembership.ps1
@@ -654,7 +654,7 @@ foreach ($device in $devices) {
             foreach ($cachedGroup in $cachedUserGroupMemberships) {
                 IF ($cachedGroup.userid -eq $PrimaryUser) {
                     write-verbose "`tusing user group membership cache for user $($PrimaryUser)"
-                    $userGroupMemerships=$cachedGroup.Groups
+                    $userGroupMemership=$cachedGroup.Groups
                 }
             }
         } else {


### PR DESCRIPTION
Update to deal with issues of incorrect groups being assigned to user devices.